### PR TITLE
ADD tossug-arena

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -1233,7 +1233,6 @@ read. Go too slow and you'll get wound up in the scroll and crushed."
 - name: tossug-arena
   url: https://github.com/tossug/tossug-arena
   info: Board-Gamelets Arena for poor AI Players.
-  screencast: https://user-images.githubusercontent.com/6536345/35132167-d0d8b240-fd04-11e7-8eff-d83152d9a3d3.gif
   
 - name: tower of mediocrity
   url: https://web.archive.org/web/20131205100524/http://www.cavein.org/~chris/code/tower/

--- a/games.yaml
+++ b/games.yaml
@@ -1230,6 +1230,11 @@ read. Go too slow and you'll get wound up in the scroll and crushed."
   info: A variant of the robots game.
   play: telnet or ssh on sdf.org
 
+- name: tossug-arena
+  url: https://github.com/tossug/tossug-arena
+  info: Board-Gamelets Arena for poor AI Players.
+  screencast: https://user-images.githubusercontent.com/6536345/35132167-d0d8b240-fd04-11e7-8eff-d83152d9a3d3.gif
+  
 - name: tower of mediocrity
   url: https://web.archive.org/web/20131205100524/http://www.cavein.org/~chris/code/tower/
   info: A tower defense game. Unfortunately, the game is quite easy to win.


### PR DESCRIPTION
TOSSUG Arena runs as a platform for building board-gamelets. Contributors can add their scripts as agent to battle with other agents, human players or themselves.