### PR TITLE
Fix Markdown URLs

### DIFF
--- a/md-generate.py
+++ b/md-generate.py
@@ -48,10 +48,10 @@ for entry in ttygames:
         print(entry['info'])
 
     if 'url' in entry:
-        print("\nWebsite: {}".format(entry['url']))
+        print("\nWebsite: <{}>".format(entry['url']))
 
     if 'wikipedia' in entry:
-        print("\nWikipedia: {}".format(entry['wikipedia']))
+        print("\nWikipedia: <{}>".format(entry['wikipedia']))
 
     if 'play' in entry:
         print("\n**Play**: `{}`".format(entry['play']))


### PR DESCRIPTION
Currently URLs on are broken on <https://ligurio.github.io/awesome-ttygames/>:

![image](https://github.com/user-attachments/assets/ee8747c3-696f-4f78-a397-1da0604ff470)

This PR simly aims to fix this so that they are rendered as proper hyperlinks in HTML.